### PR TITLE
Graphql Basics

### DIFF
--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -2,33 +2,10 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { graphqlBodySchema } from './schema';
 import {
   GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLString,
   graphql
 } from "graphql";
-import {
-  userType,
-  profileType,
-  postType,
-  memberType,
-  CreateUserInput,
-  CreateProfileInput,
-  CreatePostInput,
-  UpdateUserInput,
-  UpdateProfileInput,
-  UpdatePostInput,
-  UpdateMemberTypeInput,
-  SubscribeToUserInput,
-  UnsubscribeFromUserInput
-} from './types';
-import {
-  usersResolver,
-  profileResolver,
-  postResolver,
-  memberTypeResolver
-} from './resolvers';
+import { getQueryType } from "./queryType";
+import { getMutationType } from "./mutationType";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -41,139 +18,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply) {
-      const queryType = new GraphQLObjectType({
-        name: 'RootQueryType',
-        fields: () => ({
-          users: {
-            type: new GraphQLList(userType),
-            description: "Fetch all users",
-            resolve: async () => await usersResolver.fetchUsers(fastify),
-          },
-          profiles: {
-            type: new GraphQLList(profileType),
-            description: "Fetch all profiles",
-            resolve: async () => await profileResolver.fetchProfiles(fastify),
-          },
-          posts: {
-            type: new GraphQLList(postType),
-            description: "Fetch all posts",
-            resolve: async () => await postResolver.fetchPosts(fastify),
-          },
-          memberTypes: {
-            type: new GraphQLList(memberType),
-            description: "Fetch all member types",
-            resolve: async () => await memberTypeResolver.fetchMemberTypes(fastify),
-          },
-          user: {
-            type: userType,
-            description: "Fetch User by ID",
-            args: {
-              id: {
-                description: "User ID",
-                type: new GraphQLNonNull(GraphQLString),
-              },
-            },
-            resolve: async (_source, args) => await usersResolver.fetchUser(fastify, args)
-          },
-          profile: {
-            type: profileType,
-            description: "Fetch Profile by ID",
-            args: {
-              id: {
-                description: "Profile ID must be a string",
-                type: new GraphQLNonNull(GraphQLString),
-              },
-            },
-            resolve: async (_source, args) => await profileResolver.fetchProfile(fastify, args),
-          },
-          post: {
-            type: postType,
-            description: "Fetch Post by ID",
-            args: {
-              id: {
-                description: "Post ID must be a string",
-                type: new GraphQLNonNull(GraphQLString),
-              },
-            },
-            resolve: async (_source, args) => await postResolver.fetchPost(fastify, args),
-          },
-          memberType: {
-            type: memberType,
-            description: "Fetch Member Type by ID",
-            args: {
-              id: {
-                description: "Member Type ID must be a string",
-                type: new GraphQLNonNull(GraphQLString),
-              },
-            },
-            resolve: async (_source, args) => await memberTypeResolver.fetchMemberType(fastify, args),
-          },
-        }),
-      });
-
-      const mutationType = new GraphQLObjectType({
-        name: 'RootMutationType',
-        fields: {
-          createUser: {
-            type: userType,
-            description: "Create a new user",
-            args: { user: { type: new GraphQLNonNull(CreateUserInput) }},
-            resolve: async (_, args) => await usersResolver.createUser(fastify, args.user),
-          },
-          createProfile: {
-            type: profileType,
-            description: "Create a new profile",
-            args: { profile: { type: new GraphQLNonNull(CreateProfileInput) }},
-            resolve: async (_, args) => await profileResolver.createProfile(fastify, args.profile),
-          },
-          createPost: {
-            type: postType,
-            description: "Create a new post",
-            args: { post: { type: new GraphQLNonNull(CreatePostInput) }},
-            resolve: async (_, args) => await postResolver.createPost(fastify, args.post),
-          },
-          updateUser: {
-            type: userType,
-            description: "Update the existing user",
-            args: { user: { type: new GraphQLNonNull(UpdateUserInput) }},
-            resolve: async (_, args) => await usersResolver.updateUser(fastify, args.user),
-          },
-          updateProfile: {
-            type: profileType,
-            description: "Update user profile",
-            args: { profile: { type: new GraphQLNonNull(UpdateProfileInput) } },
-            resolve: async (_, args) => await profileResolver.updateProfile(fastify, args.profile),
-          },
-          updatePost: {
-            type: postType,
-            description: "Update user post",
-            args: { post: { type: new GraphQLNonNull(UpdatePostInput) }},
-            resolve: async (_, args) => await postResolver.updatePost(fastify, args.post),
-          },
-          updateMemberType: {
-            type: memberType,
-            description: "Update member type",
-            args: { memberType: { type: new GraphQLNonNull(UpdateMemberTypeInput)}},
-            resolve: async (_, args) => await memberTypeResolver.updateMemberType(fastify, args.memberType),
-          },
-          subscribeToUser: {
-            type: userType,
-            description: "Subscribe to User",
-            args: { user: { type: new GraphQLNonNull(SubscribeToUserInput)}},
-            resolve: async (_, args) => await usersResolver.subscribeToUser(fastify, args.user),
-          },
-          unsubscribeFromUser: {
-            type: userType,
-            description: "Unsubscribe from User",
-            args: { user: { type: new GraphQLNonNull(UnsubscribeFromUserInput)}},
-            resolve: async (_, args) => await usersResolver.unsubscribeFromUser(fastify, args.user),
-          },
-        },
-      })
-
       const schema = new GraphQLSchema({
-        query: queryType,
-        mutation: mutationType
+        query: getQueryType(fastify),
+        mutation: getMutationType(fastify)
       })
 
       return await graphql({

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -6,7 +6,7 @@ import {
 } from "graphql";
 import { getQueryType } from "./queryType";
 import { getMutationType } from "./mutationType";
-import { profileResolver, postResolver, memberTypeResolver } from "./resolvers";
+import { profileResolver, postResolver, memberTypeResolver, usersResolver } from "./resolvers";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -22,6 +22,8 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const profileDataLoader = await profileResolver.getProfileDataLoader(fastify);
       const postDataLoader = await postResolver.getPostDataLoader(fastify);
       const memberTypeDataLoader = await memberTypeResolver.getMemberTypeDataLoader(fastify);
+      const userSubscribedToDataLoader = await usersResolver.getUserSubscribedToDataLoader(fastify);
+      const subscribedToUserDataLoader = await usersResolver.getSubscribedToUserDataLoader(fastify);
 
       const schema = new GraphQLSchema({
         query: getQueryType(fastify),
@@ -36,7 +38,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
           fastify,
           profileDataLoader,
           postDataLoader,
-          memberTypeDataLoader
+          memberTypeDataLoader,
+          userSubscribedToDataLoader,
+          subscribedToUserDataLoader
         }
       });
     }

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -6,6 +6,7 @@ import {
 } from "graphql";
 import { getQueryType } from "./queryType";
 import { getMutationType } from "./mutationType";
+import { profileResolver, postResolver, memberTypeResolver } from "./resolvers";
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -18,6 +19,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply) {
+      const profileDataLoader = await profileResolver.getProfileDataLoader(fastify);
+      const postDataLoader = await postResolver.getPostDataLoader(fastify);
+      const memberTypeDataLoader = await memberTypeResolver.getMemberTypeDataLoader(fastify);
+
       const schema = new GraphQLSchema({
         query: getQueryType(fastify),
         mutation: getMutationType(fastify)
@@ -27,7 +32,12 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         schema,
         source: request.body.query as string,
         variableValues: request.body.variables,
-        contextValue: fastify
+        contextValue: {
+          fastify,
+          profileDataLoader,
+          postDataLoader,
+          memberTypeDataLoader
+        }
       });
     }
   );

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,20 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { graphqlBodySchema } from './schema';
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
+  graphql
+} from "graphql";
+import { userType, profileType, postType, memberType } from './types';
+import {
+  usersResolver,
+  profileResolver,
+  postResolver,
+  memberTypeResolver
+} from './resolvers';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -11,7 +26,91 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+      const queryType = new GraphQLObjectType({
+        name: 'Query',
+        fields: () => ({
+          users: {
+            type: new GraphQLList(userType),
+            description: "Fetch all users",
+            resolve: async () => await usersResolver.fetchUsers(fastify),
+          },
+          profiles: {
+            type: new GraphQLList(profileType),
+            description: "Fetch all profiles",
+            resolve: async () => await profileResolver.fetchProfiles(fastify),
+          },
+          posts: {
+            type: new GraphQLList(postType),
+            description: "Fetch all posts",
+            resolve: async () => await postResolver.fetchPosts(fastify),
+          },
+          memberTypes: {
+            type: new GraphQLList(memberType),
+            description: "Fetch all member types",
+            resolve: async () => await memberTypeResolver.fetchMemberTypes(fastify),
+          },
+          user: {
+            type: userType,
+            description: "Fetch User by ID",
+            args: {
+              id: {
+                description: "User ID",
+                type: new GraphQLNonNull(GraphQLString),
+              },
+            },
+            resolve: async (_source, id) => await usersResolver.fetchUser(fastify, id)
+          },
+          profile: {
+            type: profileType,
+            description: "Fetch Profile by ID",
+            args: {
+              id: {
+                description: "Profile ID must be a string",
+                type: new GraphQLNonNull(GraphQLString),
+              },
+            },
+            resolve: async (_source, id) => await profileResolver.fetchProfile(fastify, id),
+          },
+          post: {
+            type: postType,
+            description: "Fetch Post by ID",
+            args: {
+              id: {
+                description: "Post ID must be a string",
+                type: new GraphQLNonNull(GraphQLString),
+              },
+            },
+            resolve: async (_source, id) => await postResolver.fetchPost(fastify, id),
+          },
+          memberType: {
+            type: memberType,
+            description: "Fetch Member Type by ID",
+            args: {
+              id: {
+                description: "Member Type ID must be a string",
+                type: new GraphQLNonNull(GraphQLString),
+              },
+            },
+            resolve: async (_source, id) => await memberTypeResolver.fetchMemberType(fastify, id),
+          },
+        }),
+      });
+
+      // const mutationType = {
+      //
+      // }
+
+      const schema = new GraphQLSchema({
+        query: queryType,
+        // mutation: mutationType
+      })
+
+      return await graphql({
+        schema,
+        source: request.body.query as string
+      });
+    }
   );
 };
 

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -15,7 +15,13 @@ import {
   memberType,
   CreateUserInput,
   CreateProfileInput,
-  CreatePostInput
+  CreatePostInput,
+  UpdateUserInput,
+  UpdateProfileInput,
+  UpdatePostInput,
+  UpdateMemberTypeInput,
+  SubscribeToUserInput,
+  UnsubscribeFromUserInput
 } from './types';
 import {
   usersResolver,
@@ -125,8 +131,44 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
             description: "Create a new post",
             args: { post: { type: new GraphQLNonNull(CreatePostInput) }},
             resolve: async (_, args) => await postResolver.createPost(fastify, args.post),
-          }
-        }
+          },
+          updateUser: {
+            type: userType,
+            description: "Update the existing user",
+            args: { user: { type: new GraphQLNonNull(UpdateUserInput) }},
+            resolve: async (_, args) => await usersResolver.updateUser(fastify, args.user),
+          },
+          updateProfile: {
+            type: profileType,
+            description: "Update user profile",
+            args: { profile: { type: new GraphQLNonNull(UpdateProfileInput) } },
+            resolve: async (_, args) => await profileResolver.updateProfile(fastify, args.profile),
+          },
+          updatePost: {
+            type: postType,
+            description: "Update user post",
+            args: { post: { type: new GraphQLNonNull(UpdatePostInput) }},
+            resolve: async (_, args) => await postResolver.updatePost(fastify, args.post),
+          },
+          updateMemberType: {
+            type: memberType,
+            description: "Update member type",
+            args: { memberType: { type: new GraphQLNonNull(UpdateMemberTypeInput)}},
+            resolve: async (_, args) => await memberTypeResolver.updateMemberType(fastify, args.memberType),
+          },
+          subscribeToUser: {
+            type: userType,
+            description: "Subscribe to User",
+            args: { user: { type: new GraphQLNonNull(SubscribeToUserInput)}},
+            resolve: async (_, args) => await usersResolver.subscribeToUser(fastify, args.user),
+          },
+          unsubscribeFromUser: {
+            type: userType,
+            description: "Unsubscribe from User",
+            args: { user: { type: new GraphQLNonNull(UnsubscribeFromUserInput)}},
+            resolve: async (_, args) => await usersResolver.unsubscribeFromUser(fastify, args.user),
+          },
+        },
       })
 
       const schema = new GraphQLSchema({

--- a/src/routes/graphql/mutationType.ts
+++ b/src/routes/graphql/mutationType.ts
@@ -1,0 +1,80 @@
+import {GraphQLNonNull, GraphQLObjectType} from "graphql";
+import {
+  CreatePostInput,
+  CreateProfileInput,
+  CreateUserInput,
+  memberType,
+  postType,
+  profileType,
+  UpdateMemberTypeInput,
+  UpdatePostInput,
+  UpdateUserInput,
+  userType,
+  SubscribeToUserInput,
+  UnsubscribeFromUserInput,
+  UpdateProfileInput
+} from "./types";
+import {memberTypeResolver, postResolver, profileResolver, usersResolver} from "./resolvers";
+import {FastifyInstance} from "fastify";
+
+export const getMutationType = (fastify: FastifyInstance) => {
+  return new GraphQLObjectType({
+    name: 'RootMutationType',
+    fields: {
+      createUser: {
+        type: userType,
+        description: "Create a new user",
+        args: { user: { type: new GraphQLNonNull(CreateUserInput) }},
+        resolve: async (_, args) => await usersResolver.createUser(fastify, args.user),
+      },
+      createProfile: {
+        type: profileType,
+        description: "Create a new profile",
+        args: { profile: { type: new GraphQLNonNull(CreateProfileInput) }},
+        resolve: async (_, args) => await profileResolver.createProfile(fastify, args.profile),
+      },
+      createPost: {
+        type: postType,
+        description: "Create a new post",
+        args: { post: { type: new GraphQLNonNull(CreatePostInput) }},
+        resolve: async (_, args) => await postResolver.createPost(fastify, args.post),
+      },
+      updateUser: {
+        type: userType,
+        description: "Update the existing user",
+        args: { user: { type: new GraphQLNonNull(UpdateUserInput) }},
+        resolve: async (_, args) => await usersResolver.updateUser(fastify, args.user),
+      },
+      updateProfile: {
+        type: profileType,
+        description: "Update user profile",
+        args: { profile: { type: new GraphQLNonNull(UpdateProfileInput) } },
+        resolve: async (_, args) => await profileResolver.updateProfile(fastify, args.profile),
+      },
+      updatePost: {
+        type: postType,
+        description: "Update user post",
+        args: { post: { type: new GraphQLNonNull(UpdatePostInput) }},
+        resolve: async (_, args) => await postResolver.updatePost(fastify, args.post),
+      },
+      updateMemberType: {
+        type: memberType,
+        description: "Update member type",
+        args: { memberType: { type: new GraphQLNonNull(UpdateMemberTypeInput)}},
+        resolve: async (_, args) => await memberTypeResolver.updateMemberType(fastify, args.memberType),
+      },
+      subscribeToUser: {
+        type: userType,
+        description: "Subscribe to User",
+        args: { user: { type: new GraphQLNonNull(SubscribeToUserInput)}},
+        resolve: async (_, args) => await usersResolver.subscribeToUser(fastify, args.user),
+      },
+      unsubscribeFromUser: {
+        type: userType,
+        description: "Unsubscribe from User",
+        args: { user: { type: new GraphQLNonNull(UnsubscribeFromUserInput)}},
+        resolve: async (_, args) => await usersResolver.unsubscribeFromUser(fastify, args.user),
+      },
+    },
+  })
+}

--- a/src/routes/graphql/queryType.ts
+++ b/src/routes/graphql/queryType.ts
@@ -1,0 +1,76 @@
+import {GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString} from "graphql";
+import {memberTypeResolver, postResolver, profileResolver, usersResolver} from "./resolvers";
+import {memberType, postType, profileType, userType} from "./types";
+import {FastifyInstance} from "fastify";
+
+export const getQueryType = (fastify: FastifyInstance) => {
+  return new GraphQLObjectType({
+    name: 'RootQueryType',
+    fields: () => ({
+      users: {
+        type: new GraphQLList(userType),
+        description: "Fetch all users",
+        resolve: async () => await usersResolver.fetchUsers(fastify),
+      },
+      profiles: {
+        type: new GraphQLList(profileType),
+        description: "Fetch all profiles",
+        resolve: async () => await profileResolver.fetchProfiles(fastify),
+      },
+      posts: {
+        type: new GraphQLList(postType),
+        description: "Fetch all posts",
+        resolve: async () => await postResolver.fetchPosts(fastify),
+      },
+      memberTypes: {
+        type: new GraphQLList(memberType),
+        description: "Fetch all member types",
+        resolve: async () => await memberTypeResolver.fetchMemberTypes(fastify),
+      },
+      user: {
+        type: userType,
+        description: "Fetch User by ID",
+        args: {
+          id: {
+            description: "User ID",
+            type: new GraphQLNonNull(GraphQLString),
+          },
+        },
+        resolve: async (_source, args) => await usersResolver.fetchUser(fastify, args)
+      },
+      profile: {
+        type: profileType,
+        description: "Fetch Profile by ID",
+        args: {
+          id: {
+            description: "Profile ID must be a string",
+            type: new GraphQLNonNull(GraphQLString),
+          },
+        },
+        resolve: async (_source, args) => await profileResolver.fetchProfile(fastify, args),
+      },
+      post: {
+        type: postType,
+        description: "Fetch Post by ID",
+        args: {
+          id: {
+            description: "Post ID must be a string",
+            type: new GraphQLNonNull(GraphQLString),
+          },
+        },
+        resolve: async (_source, args) => await postResolver.fetchPost(fastify, args),
+      },
+      memberType: {
+        type: memberType,
+        description: "Fetch Member Type by ID",
+        args: {
+          id: {
+            description: "Member Type ID must be a string",
+            type: new GraphQLNonNull(GraphQLString),
+          },
+        },
+        resolve: async (_source, args) => await memberTypeResolver.fetchMemberType(fastify, args),
+      },
+    }),
+  });
+}

--- a/src/routes/graphql/queryType.ts
+++ b/src/routes/graphql/queryType.ts
@@ -7,27 +7,27 @@ export const getQueryType = (fastify: FastifyInstance) => {
   return new GraphQLObjectType({
     name: 'RootQueryType',
     fields: () => ({
-      users: {
+      fetchUsers: {
         type: new GraphQLList(userType),
         description: "Fetch all users",
         resolve: async () => await usersResolver.fetchUsers(fastify),
       },
-      profiles: {
+      fetchProfiles: {
         type: new GraphQLList(profileType),
         description: "Fetch all profiles",
         resolve: async () => await profileResolver.fetchProfiles(fastify),
       },
-      posts: {
+      fetchPosts: {
         type: new GraphQLList(postType),
         description: "Fetch all posts",
         resolve: async () => await postResolver.fetchPosts(fastify),
       },
-      memberTypes: {
+      fetchMemberTypes: {
         type: new GraphQLList(memberType),
         description: "Fetch all member types",
         resolve: async () => await memberTypeResolver.fetchMemberTypes(fastify),
       },
-      user: {
+      fetchUser: {
         type: userType,
         description: "Fetch User by ID",
         args: {
@@ -38,7 +38,7 @@ export const getQueryType = (fastify: FastifyInstance) => {
         },
         resolve: async (_source, args) => await usersResolver.fetchUser(fastify, args)
       },
-      profile: {
+      fetchProfile: {
         type: profileType,
         description: "Fetch Profile by ID",
         args: {
@@ -49,7 +49,7 @@ export const getQueryType = (fastify: FastifyInstance) => {
         },
         resolve: async (_source, args) => await profileResolver.fetchProfile(fastify, args),
       },
-      post: {
+      fetchPost: {
         type: postType,
         description: "Fetch Post by ID",
         args: {
@@ -60,7 +60,7 @@ export const getQueryType = (fastify: FastifyInstance) => {
         },
         resolve: async (_source, args) => await postResolver.fetchPost(fastify, args),
       },
-      memberType: {
+      fetchMemberType: {
         type: memberType,
         description: "Fetch Member Type by ID",
         args: {

--- a/src/routes/graphql/resolvers/index.ts
+++ b/src/routes/graphql/resolvers/index.ts
@@ -1,0 +1,11 @@
+import usersResolver from "./users.resolver"
+import profileResolver from "./profile.resolver"
+import postResolver from "./post.resolver"
+import memberTypeResolver from "./memberType.resolver"
+
+export {
+  usersResolver,
+  profileResolver,
+  postResolver,
+  memberTypeResolver
+}

--- a/src/routes/graphql/resolvers/memberType.resolver.ts
+++ b/src/routes/graphql/resolvers/memberType.resolver.ts
@@ -1,4 +1,6 @@
 import { FastifyInstance } from "fastify";
+import { MemberTypeEntity } from "../../../utils/DB/entities/DBMemberTypes";
+import * as DataLoader from "dataloader";
 
 class MemberTypeResolver {
   public async fetchMemberTypes(fastify: FastifyInstance) {
@@ -33,6 +35,25 @@ class MemberTypeResolver {
     }
 
     return await fastify.db.memberTypes.change(id, body)
+  }
+
+  public async getMemberTypeDataLoader(fastify: FastifyInstance) {
+    return new DataLoader(async (memberTypeIDs) => {
+      const memberTypes = await fastify.db.memberTypes.findMany()
+
+      let found
+      const result = memberTypeIDs.reduce((acc: any, currentUserID) => {
+        found = memberTypes?.find((memberType) => memberType.id === currentUserID)
+
+        if (found) {
+          acc.push(found)
+        }
+
+        return acc
+      }, [])
+
+      return result as MemberTypeEntity[]
+    })
   }
 }
 

--- a/src/routes/graphql/resolvers/memberType.resolver.ts
+++ b/src/routes/graphql/resolvers/memberType.resolver.ts
@@ -5,9 +5,9 @@ class MemberTypeResolver {
     return await fastify.db.memberTypes.findMany();
   }
 
-  public async fetchMemberType(fastify: FastifyInstance, id: string) {
+  public async fetchMemberType(fastify: FastifyInstance, args: { id: string }) {
     const memberType = await fastify.db.memberTypes.findOne({
-      key: "id", equals: id
+      key: "id", equals: args?.id
     })
 
     if (!memberType) {

--- a/src/routes/graphql/resolvers/memberType.resolver.ts
+++ b/src/routes/graphql/resolvers/memberType.resolver.ts
@@ -16,6 +16,24 @@ class MemberTypeResolver {
 
     return memberType
   }
+
+  public async updateMemberType(fastify: FastifyInstance, args: {
+    id: string,
+    discount: number,
+    monthPostsLimit: number
+  }) {
+    const {id, ...body} = args
+
+    const memberType = await fastify.db.memberTypes.findOne({
+      key: "id", equals: id
+    })
+
+    if (!memberType) {
+      throw fastify.httpErrors.badRequest()
+    }
+
+    return await fastify.db.memberTypes.change(id, body)
+  }
 }
 
 export default new MemberTypeResolver()

--- a/src/routes/graphql/resolvers/memberType.resolver.ts
+++ b/src/routes/graphql/resolvers/memberType.resolver.ts
@@ -1,0 +1,21 @@
+import { FastifyInstance } from "fastify";
+
+class MemberTypeResolver {
+  public async fetchMemberTypes(fastify: FastifyInstance) {
+    return await fastify.db.memberTypes.findMany();
+  }
+
+  public async fetchMemberType(fastify: FastifyInstance, id: string) {
+    const memberType = await fastify.db.memberTypes.findOne({
+      key: "id", equals: id
+    })
+
+    if (!memberType) {
+      throw fastify.httpErrors.notFound("Member Type is not found");
+    }
+
+    return memberType
+  }
+}
+
+export default new MemberTypeResolver()

--- a/src/routes/graphql/resolvers/memberType.resolver.ts
+++ b/src/routes/graphql/resolvers/memberType.resolver.ts
@@ -1,5 +1,4 @@
 import { FastifyInstance } from "fastify";
-import { MemberTypeEntity } from "../../../utils/DB/entities/DBMemberTypes";
 import * as DataLoader from "dataloader";
 
 class MemberTypeResolver {
@@ -41,18 +40,8 @@ class MemberTypeResolver {
     return new DataLoader(async (memberTypeIDs) => {
       const memberTypes = await fastify.db.memberTypes.findMany()
 
-      let found
-      const result = memberTypeIDs.reduce((acc: any, currentUserID) => {
-        found = memberTypes?.find((memberType) => memberType.id === currentUserID)
-
-        if (found) {
-          acc.push(found)
-        }
-
-        return acc
-      }, [])
-
-      return result as MemberTypeEntity[]
+      return memberTypeIDs?.map((memberTypeID) =>
+        memberTypes?.find((memberType) => memberType?.id === memberTypeID));
     })
   }
 }

--- a/src/routes/graphql/resolvers/post.resolver.ts
+++ b/src/routes/graphql/resolvers/post.resolver.ts
@@ -24,6 +24,23 @@ class PostResolver {
   }) {
     return await fastify.db.posts.create(args)
   }
+
+  public async updatePost(fastify: FastifyInstance, args: {
+    id: string,
+    title: string,
+    content: string
+  }) {
+    const {id, ...body} = args
+
+    const post =
+      await fastify.db.posts.findOne({ key: 'id', equals: id });
+
+    if (!post) {
+      throw fastify.httpErrors.badRequest()
+    }
+
+    return fastify.db.posts.change(id, body);
+  }
 }
 
 export default new PostResolver()

--- a/src/routes/graphql/resolvers/post.resolver.ts
+++ b/src/routes/graphql/resolvers/post.resolver.ts
@@ -1,6 +1,5 @@
 import { FastifyInstance } from "fastify";
 import * as DataLoader from "dataloader";
-import { PostEntity } from "../../../utils/DB/entities/DBPosts";
 
 class PostResolver {
   public async fetchPosts(fastify: FastifyInstance) {
@@ -48,18 +47,7 @@ class PostResolver {
     return new DataLoader(async (userIDs) => {
       const posts = await fastify.db.posts.findMany()
 
-      let found
-      const result = userIDs.reduce((acc: any, currentUserID) => {
-        found = posts?.find((post) => post.userId === currentUserID)
-
-        if (found) {
-          acc.push(found)
-        }
-
-        return acc
-      }, [])
-
-      return result as PostEntity[]
+      return userIDs?.map((userID) => posts?.find((post) => post?.userId === userID));
     })
   }
 }

--- a/src/routes/graphql/resolvers/post.resolver.ts
+++ b/src/routes/graphql/resolvers/post.resolver.ts
@@ -5,9 +5,9 @@ class PostResolver {
     return await fastify.db.posts.findMany();
   }
 
-  public async fetchPost(fastify: FastifyInstance, id: string) {
+  public async fetchPost(fastify: FastifyInstance, args: { id: string }) {
     const post = await fastify.db.posts.findOne({
-      key: "id", equals: id
+      key: "id", equals: args?.id
     })
 
     if (!post) {
@@ -15,6 +15,14 @@ class PostResolver {
     }
 
     return post
+  }
+
+  public async createPost(fastify: FastifyInstance, args: {
+    userId: string,
+    title: string,
+    content: string
+  }) {
+    return await fastify.db.posts.create(args)
   }
 }
 

--- a/src/routes/graphql/resolvers/post.resolver.ts
+++ b/src/routes/graphql/resolvers/post.resolver.ts
@@ -1,0 +1,21 @@
+import { FastifyInstance } from "fastify";
+
+class PostResolver {
+  public async fetchPosts(fastify: FastifyInstance) {
+    return await fastify.db.posts.findMany();
+  }
+
+  public async fetchPost(fastify: FastifyInstance, id: string) {
+    const post = await fastify.db.posts.findOne({
+      key: "id", equals: id
+    })
+
+    if (!post) {
+      throw fastify.httpErrors.notFound("Post is not found");
+    }
+
+    return post
+  }
+}
+
+export default new PostResolver()

--- a/src/routes/graphql/resolvers/post.resolver.ts
+++ b/src/routes/graphql/resolvers/post.resolver.ts
@@ -1,4 +1,6 @@
 import { FastifyInstance } from "fastify";
+import * as DataLoader from "dataloader";
+import { PostEntity } from "../../../utils/DB/entities/DBPosts";
 
 class PostResolver {
   public async fetchPosts(fastify: FastifyInstance) {
@@ -40,6 +42,25 @@ class PostResolver {
     }
 
     return fastify.db.posts.change(id, body);
+  }
+
+  public async getPostDataLoader(fastify: FastifyInstance) {
+    return new DataLoader(async (userIDs) => {
+      const posts = await fastify.db.posts.findMany()
+
+      let found
+      const result = userIDs.reduce((acc: any, currentUserID) => {
+        found = posts?.find((post) => post.userId === currentUserID)
+
+        if (found) {
+          acc.push(found)
+        }
+
+        return acc
+      }, [])
+
+      return result as PostEntity[]
+    })
   }
 }
 

--- a/src/routes/graphql/resolvers/profile.resolver.ts
+++ b/src/routes/graphql/resolvers/profile.resolver.ts
@@ -29,6 +29,40 @@ class ProfileResolver {
   }) {
    return await fastify.db.profiles.create(args)
   }
+
+  public async updateProfile(fastify: FastifyInstance, args: {
+    id: string,
+    avatar: string,
+    sex: string,
+    birthday: number,
+    country: string,
+    street: string,
+    city: string,
+    memberTypeId: string
+  }) {
+    const {id, ...body} = args
+
+    const profile =
+      await fastify.db.profiles.findOne({ key: 'id', equals: id });
+
+    if (!profile) {
+      throw fastify.httpErrors.badRequest()
+    }
+
+    if (args?.memberTypeId) {
+      const memberType =
+        await fastify.db.memberTypes.findOne({
+          key: "id",
+          equals: args.memberTypeId
+        })
+
+      if (!memberType) {
+        throw fastify.httpErrors.badRequest()
+      }
+    }
+
+    return fastify.db.profiles.change(id, body);
+  }
 }
 
 export default new ProfileResolver()

--- a/src/routes/graphql/resolvers/profile.resolver.ts
+++ b/src/routes/graphql/resolvers/profile.resolver.ts
@@ -1,0 +1,22 @@
+import { FastifyInstance } from "fastify";
+
+class ProfileResolver {
+  public async fetchProfiles(fastify: FastifyInstance) {
+    return await fastify.db.profiles.findMany();
+  }
+
+  public async fetchProfile(fastify: FastifyInstance, id: string) {
+    const profile = await fastify.db.profiles.findOne({
+      key: "id", equals: id
+    })
+
+    if (!profile) {
+      throw fastify.httpErrors.notFound("Profile is not found");
+    }
+
+    return profile
+  }
+}
+
+export default new ProfileResolver()
+

--- a/src/routes/graphql/resolvers/profile.resolver.ts
+++ b/src/routes/graphql/resolvers/profile.resolver.ts
@@ -5,9 +5,9 @@ class ProfileResolver {
     return await fastify.db.profiles.findMany();
   }
 
-  public async fetchProfile(fastify: FastifyInstance, id: string) {
+  public async fetchProfile(fastify: FastifyInstance, args: { id: string }) {
     const profile = await fastify.db.profiles.findOne({
-      key: "id", equals: id
+      key: "id", equals: args?.id
     })
 
     if (!profile) {
@@ -15,6 +15,19 @@ class ProfileResolver {
     }
 
     return profile
+  }
+
+  public async createProfile(fastify: FastifyInstance, args: {
+    avatar: string,
+    sex: string,
+    birthday: number,
+    country: string,
+    street: string,
+    city: string,
+    userId: string,
+    memberTypeId: string
+  }) {
+   return await fastify.db.profiles.create(args)
   }
 }
 

--- a/src/routes/graphql/resolvers/profile.resolver.ts
+++ b/src/routes/graphql/resolvers/profile.resolver.ts
@@ -1,4 +1,6 @@
 import { FastifyInstance } from "fastify";
+import * as DataLoader from "dataloader";
+import { ProfileEntity } from "../../../utils/DB/entities/DBProfiles";
 
 class ProfileResolver {
   public async fetchProfiles(fastify: FastifyInstance) {
@@ -62,6 +64,25 @@ class ProfileResolver {
     }
 
     return fastify.db.profiles.change(id, body);
+  }
+
+  public async getProfileDataLoader(fastify: FastifyInstance) {
+    return new DataLoader(async (userIDs) => {
+      const profiles = await fastify.db.profiles.findMany();
+
+      let found
+      const result = userIDs.reduce((acc: any, currentUserID) => {
+        found = profiles?.find((profile) => profile.userId === currentUserID)
+
+        if (found) {
+          acc.push(found)
+        }
+
+        return acc
+      }, [])
+
+      return result as ProfileEntity[]
+    })
   }
 }
 

--- a/src/routes/graphql/resolvers/profile.resolver.ts
+++ b/src/routes/graphql/resolvers/profile.resolver.ts
@@ -1,6 +1,5 @@
 import { FastifyInstance } from "fastify";
 import * as DataLoader from "dataloader";
-import { ProfileEntity } from "../../../utils/DB/entities/DBProfiles";
 
 class ProfileResolver {
   public async fetchProfiles(fastify: FastifyInstance) {
@@ -70,18 +69,7 @@ class ProfileResolver {
     return new DataLoader(async (userIDs) => {
       const profiles = await fastify.db.profiles.findMany();
 
-      let found
-      const result = userIDs.reduce((acc: any, currentUserID) => {
-        found = profiles?.find((profile) => profile.userId === currentUserID)
-
-        if (found) {
-          acc.push(found)
-        }
-
-        return acc
-      }, [])
-
-      return result as ProfileEntity[]
+      return userIDs?.map((userID) => profiles?.find((profile) => profile?.userId === userID));
     })
   }
 }

--- a/src/routes/graphql/resolvers/users.resolver.ts
+++ b/src/routes/graphql/resolvers/users.resolver.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from "fastify";
+import * as DataLoader from "dataloader";
 
 class UsersResolver {
   public async fetchUsers(fastify: FastifyInstance) {
@@ -104,6 +105,23 @@ class UsersResolver {
       userId,
       { subscribedToUserIds }
     )
+  }
+
+  public async getUserSubscribedToDataLoader(fastify: FastifyInstance) {
+    return new DataLoader(async (userIDs) => {
+      const users = await fastify.db.users.findMany();
+
+      return userIDs?.map((userId) =>
+        users?.find((user) => user.subscribedToUserIds?.includes(userId as string)));
+    })
+  }
+
+  public async getSubscribedToUserDataLoader(fastify: FastifyInstance) {
+    return new DataLoader(async (userIDs) => {
+      const users = await fastify.db.users.findMany();
+
+      return userIDs?.map((userID) => users?.find((user) => user?.id === userID));
+    })
   }
 }
 

--- a/src/routes/graphql/resolvers/users.resolver.ts
+++ b/src/routes/graphql/resolvers/users.resolver.ts
@@ -25,6 +25,86 @@ class UsersResolver {
   }) {
     return await fastify.db.users.create(args)
   }
+
+  public async updateUser(fastify: FastifyInstance, args: {
+    id: string,
+    firstName: string,
+    lastName: string,
+    email: string
+  }) {
+    const {id, ...body} = args
+    const user = await fastify.db.users.findOne({ key: 'id', equals: id });
+
+    if (!user) {
+      throw fastify.httpErrors.notFound('User is not found');
+    }
+
+    return fastify.db.users.change(id, body);
+  }
+
+  public async subscribeToUser(fastify: FastifyInstance, args: {
+    userId: string,
+    subscribeToUserId: string
+  }) {
+    const {userId, subscribeToUserId} = args
+
+    const user = await fastify.db.users
+      .findOne({ key: "id", equals: userId })
+
+    const subscribeToUser = await fastify.db.users
+      .findOne({ key: "id", equals: subscribeToUserId })
+
+    if (!user || !subscribeToUser) {
+      throw fastify.httpErrors.notFound();
+    }
+
+    const isAlreadySubscribed =
+      user.subscribedToUserIds.includes(subscribeToUserId);
+
+    if (isAlreadySubscribed || userId === subscribeToUserId) {
+      throw fastify.httpErrors.badRequest();
+    }
+
+    user.subscribedToUserIds.push(subscribeToUserId)
+    const subscribedToUserIds = [...user.subscribedToUserIds]
+
+    return await fastify.db.users.change(
+      userId,
+      { subscribedToUserIds }
+    )
+  }
+
+  public async unsubscribeFromUser(fastify: FastifyInstance, args: {
+    userId: string,
+    unsubscribeFromUserId: string
+  }) {
+    const { userId, unsubscribeFromUserId } = args
+
+    const user = await fastify.db.users
+      .findOne({ key: "id", equals: userId })
+
+    const unSubscribeToUser = await fastify.db.users
+      .findOne({ key: "id", equals: unsubscribeFromUserId })
+
+    if (!user || !unSubscribeToUser) {
+      throw fastify.httpErrors.notFound();
+    }
+
+    const isSubscribed =
+      user.subscribedToUserIds.includes(unsubscribeFromUserId)
+
+    if (!isSubscribed || userId === unsubscribeFromUserId) {
+      throw fastify.httpErrors.badRequest();
+    }
+
+    const subscribedToUserIds =
+      [...user.subscribedToUserIds].filter((userID) => userID !== unsubscribeFromUserId)
+
+    return await fastify.db.users.change(
+      userId,
+      { subscribedToUserIds }
+    )
+  }
 }
 
 export default new UsersResolver()

--- a/src/routes/graphql/resolvers/users.resolver.ts
+++ b/src/routes/graphql/resolvers/users.resolver.ts
@@ -1,0 +1,22 @@
+import { FastifyInstance } from "fastify";
+
+class UsersResolver {
+  public async fetchUsers(fastify: FastifyInstance) {
+    return await fastify.db.users.findMany()
+  }
+
+ public async fetchUser(fastify: FastifyInstance, id: string) {
+   const user =
+     await fastify.db.users.findOne({
+       key: "id", equals: id
+     })
+
+   if (!user) {
+     throw fastify.httpErrors.notFound("User is not found");
+   }
+
+   return user
+ }
+}
+
+export default new UsersResolver()

--- a/src/routes/graphql/resolvers/users.resolver.ts
+++ b/src/routes/graphql/resolvers/users.resolver.ts
@@ -5,10 +5,10 @@ class UsersResolver {
     return await fastify.db.users.findMany()
   }
 
- public async fetchUser(fastify: FastifyInstance, id: string) {
+ public async fetchUser(fastify: FastifyInstance, args: { id: string }) {
    const user =
      await fastify.db.users.findOne({
-       key: "id", equals: id
+       key: "id", equals: args?.id
      })
 
    if (!user) {
@@ -17,6 +17,14 @@ class UsersResolver {
 
    return user
  }
+
+  public async createUser(fastify: FastifyInstance, args: {
+    firstName: string,
+    lastName: string,
+    email: string
+  }) {
+    return await fastify.db.users.create(args)
+  }
 }
 
 export default new UsersResolver()

--- a/src/routes/graphql/types/index.ts
+++ b/src/routes/graphql/types/index.ts
@@ -1,0 +1,11 @@
+import { userType } from './users';
+import { profileType } from "./profiles";
+import { postType } from "./posts";
+import { memberType } from "./memberTypes";
+
+export {
+  userType,
+  profileType,
+  postType,
+  memberType
+}

--- a/src/routes/graphql/types/index.ts
+++ b/src/routes/graphql/types/index.ts
@@ -1,7 +1,13 @@
-import { userType, CreateUserInput } from './users';
-import { profileType, CreateProfileInput } from "./profiles";
-import { postType, CreatePostInput } from "./posts";
-import { memberType } from "./memberTypes";
+import {
+  userType,
+  CreateUserInput,
+  UpdateUserInput,
+  SubscribeToUserInput,
+  UnsubscribeFromUserInput
+} from './users';
+import { profileType, CreateProfileInput, UpdateProfileInput } from "./profiles";
+import { postType, CreatePostInput, UpdatePostInput } from "./posts";
+import { memberType, UpdateMemberTypeInput } from "./memberTypes";
 
 export {
   userType,
@@ -10,5 +16,11 @@ export {
   memberType,
   CreateUserInput,
   CreateProfileInput,
-  CreatePostInput
+  CreatePostInput,
+  UpdateUserInput,
+  UpdateProfileInput,
+  UpdatePostInput,
+  UpdateMemberTypeInput,
+  SubscribeToUserInput,
+  UnsubscribeFromUserInput
 }

--- a/src/routes/graphql/types/index.ts
+++ b/src/routes/graphql/types/index.ts
@@ -1,11 +1,14 @@
-import { userType } from './users';
-import { profileType } from "./profiles";
-import { postType } from "./posts";
+import { userType, CreateUserInput } from './users';
+import { profileType, CreateProfileInput } from "./profiles";
+import { postType, CreatePostInput } from "./posts";
 import { memberType } from "./memberTypes";
 
 export {
   userType,
   profileType,
   postType,
-  memberType
+  memberType,
+  CreateUserInput,
+  CreateProfileInput,
+  CreatePostInput
 }

--- a/src/routes/graphql/types/memberTypes.ts
+++ b/src/routes/graphql/types/memberTypes.ts
@@ -1,0 +1,15 @@
+import {
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString
+} from "graphql";
+
+export const memberType = new GraphQLObjectType({
+  name: "MemberType",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    discount: { type: new GraphQLNonNull(GraphQLInt) },
+    monthPostsLimit: { type: new GraphQLNonNull(GraphQLInt) },
+  })
+})

--- a/src/routes/graphql/types/memberTypes.ts
+++ b/src/routes/graphql/types/memberTypes.ts
@@ -2,10 +2,11 @@ import {
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
-  GraphQLString
+  GraphQLString,
+  GraphQLInputObjectType
 } from "graphql";
 
-export const memberType = new GraphQLObjectType({
+const memberType = new GraphQLObjectType({
   name: "MemberType",
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLString) },
@@ -13,3 +14,14 @@ export const memberType = new GraphQLObjectType({
     monthPostsLimit: { type: new GraphQLNonNull(GraphQLInt) },
   })
 })
+
+const UpdateMemberTypeInput = new GraphQLInputObjectType({
+  name: 'UpdateMemberTypeInput',
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  },
+})
+
+export { memberType, UpdateMemberTypeInput }

--- a/src/routes/graphql/types/posts.ts
+++ b/src/routes/graphql/types/posts.ts
@@ -1,0 +1,15 @@
+import {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString
+} from "graphql";
+
+export const postType = new GraphQLObjectType({
+  name: "Post",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString), format: 'uuid' },
+  })
+})

--- a/src/routes/graphql/types/posts.ts
+++ b/src/routes/graphql/types/posts.ts
@@ -25,4 +25,13 @@ const CreatePostInput = new GraphQLInputObjectType({
   },
 })
 
-export { postType, CreatePostInput }
+const UpdatePostInput = new GraphQLInputObjectType({
+  name: 'UpdatePostInput',
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+  },
+})
+
+export { postType, CreatePostInput, UpdatePostInput }

--- a/src/routes/graphql/types/posts.ts
+++ b/src/routes/graphql/types/posts.ts
@@ -1,10 +1,12 @@
 import {
   GraphQLObjectType,
   GraphQLNonNull,
-  GraphQLString
+  GraphQLString,
+  GraphQLInputObjectType,
+  GraphQLID
 } from "graphql";
 
-export const postType = new GraphQLObjectType({
+const postType = new GraphQLObjectType({
   name: "Post",
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLString) },
@@ -13,3 +15,14 @@ export const postType = new GraphQLObjectType({
     userId: { type: new GraphQLNonNull(GraphQLString), format: 'uuid' },
   })
 })
+
+const CreatePostInput = new GraphQLInputObjectType({
+  name: 'CreatePostInput',
+  fields: {
+    userId: { type: new GraphQLNonNull(GraphQLID), description: "Post ID" },
+    title: { type: new GraphQLNonNull(GraphQLString), description: "Post title" },
+    content: { type: new GraphQLNonNull(GraphQLString), description: "Post description" },
+  },
+})
+
+export { postType, CreatePostInput }

--- a/src/routes/graphql/types/profiles.ts
+++ b/src/routes/graphql/types/profiles.ts
@@ -1,0 +1,21 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt
+} from "graphql";
+
+export const profileType = new GraphQLObjectType({
+  name: "Profile",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString), format: 'uuid' },
+    memberTypeId: { type: new GraphQLNonNull(GraphQLString)},
+  })
+})

--- a/src/routes/graphql/types/profiles.ts
+++ b/src/routes/graphql/types/profiles.ts
@@ -34,4 +34,18 @@ const CreateProfileInput = new GraphQLInputObjectType({
   },
 });
 
-export { profileType, CreateProfileInput };
+const UpdateProfileInput = new GraphQLInputObjectType({
+  name: 'UpdateProfileInput',
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLString },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+  },
+});
+
+export { profileType, CreateProfileInput, UpdateProfileInput };

--- a/src/routes/graphql/types/profiles.ts
+++ b/src/routes/graphql/types/profiles.ts
@@ -2,16 +2,16 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLInt
+  GraphQLInputObjectType
 } from "graphql";
 
-export const profileType = new GraphQLObjectType({
+const profileType = new GraphQLObjectType({
   name: "Profile",
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLString) },
     avatar: { type: new GraphQLNonNull(GraphQLString) },
     sex: { type: new GraphQLNonNull(GraphQLString) },
-    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    birthday: { type: new GraphQLNonNull(GraphQLString) },
     country: { type: new GraphQLNonNull(GraphQLString) },
     street: { type: new GraphQLNonNull(GraphQLString) },
     city: { type: new GraphQLNonNull(GraphQLString) },
@@ -19,3 +19,19 @@ export const profileType = new GraphQLObjectType({
     memberTypeId: { type: new GraphQLNonNull(GraphQLString)},
   })
 })
+
+const CreateProfileInput = new GraphQLInputObjectType({
+  name: 'CreateProfileInput',
+  fields: {
+    avatar: { type: new GraphQLNonNull(GraphQLString), description: "User avatar" },
+    sex: { type: new GraphQLNonNull(GraphQLString), description: "User sex" },
+    birthday: { type: new GraphQLNonNull(GraphQLString), description: "User birthday" },
+    country: { type: new GraphQLNonNull(GraphQLString), description: "User country" },
+    street: { type: new GraphQLNonNull(GraphQLString), description: "User street" },
+    city: { type: new GraphQLNonNull(GraphQLString), description: "User city" },
+    userId: { type: new GraphQLNonNull(GraphQLString), description: "User ID" },
+    memberTypeId: { type: new GraphQLNonNull(GraphQLString), description: "Member type ID" }
+  },
+});
+
+export { profileType, CreateProfileInput };

--- a/src/routes/graphql/types/users.ts
+++ b/src/routes/graphql/types/users.ts
@@ -26,4 +26,30 @@ const CreateUserInput = new GraphQLInputObjectType({
   },
 });
 
-export { CreateUserInput, userType };
+const UpdateUserInput = new GraphQLInputObjectType({
+  name: 'UpdateUserInput',
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString), description: "User ID" },
+    firstName: { type: new GraphQLNonNull(GraphQLString), description: "First name" },
+    lastName: { type: new GraphQLNonNull(GraphQLString), description: "Last name" },
+    email: { type: new GraphQLNonNull(GraphQLString), description: "User email" },
+  },
+});
+
+const SubscribeToUserInput = new GraphQLInputObjectType({
+  name: 'SubscribeToUserInput',
+  fields: {
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    subscribeToUserId: { type: new GraphQLNonNull(GraphQLString) },
+  },
+});
+
+const UnsubscribeFromUserInput = new GraphQLInputObjectType({
+  name: 'UnsubscribeFromUserInput',
+  fields: {
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    unsubscribeFromUserId: { type: new GraphQLNonNull(GraphQLString) },
+  },
+});
+
+export { CreateUserInput, userType, UpdateUserInput, SubscribeToUserInput, UnsubscribeFromUserInput };

--- a/src/routes/graphql/types/users.ts
+++ b/src/routes/graphql/types/users.ts
@@ -3,9 +3,10 @@ import {
   GraphQLNonNull,
   GraphQLString,
   GraphQLList,
+  GraphQLInputObjectType
 } from "graphql";
 
-export const userType = new GraphQLObjectType({
+const userType = new GraphQLObjectType({
   name: "User",
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLString) },
@@ -15,3 +16,14 @@ export const userType = new GraphQLObjectType({
     subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
   }),
 })
+
+const CreateUserInput = new GraphQLInputObjectType({
+  name: 'CreateUserInput',
+  fields: {
+    firstName: { type: new GraphQLNonNull(GraphQLString), description: "First name" },
+    lastName: { type: new GraphQLNonNull(GraphQLString), description: "Last name" },
+    email: { type: new GraphQLNonNull(GraphQLString), description: "User email" },
+  },
+});
+
+export { CreateUserInput, userType };

--- a/src/routes/graphql/types/users.ts
+++ b/src/routes/graphql/types/users.ts
@@ -1,0 +1,17 @@
+import {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLList,
+} from "graphql";
+
+export const userType = new GraphQLObjectType({
+  name: "User",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    firstName: { type: new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+  }),
+})

--- a/src/routes/graphql/types/users.ts
+++ b/src/routes/graphql/types/users.ts
@@ -8,7 +8,7 @@ import {
 import { UserEntity } from '../../../utils/DB/entities/DBUsers';
 import { profileType, postType, memberType } from "./";
 
-const userType = new GraphQLObjectType({
+const userType: any = new GraphQLObjectType({
   name: "User",
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLString) },
@@ -30,11 +30,20 @@ const userType = new GraphQLObjectType({
         const profile = await context.profileDataLoader.load(user.id);
 
         if (!profile) {
-          return
+          return [];
         }
 
         return context.memberTypeDataLoader.load(profile.memberTypeId);
       },
+    },
+    subscribedToUser: {
+      type: new GraphQLList(userType),
+      resolve: async (user: UserEntity, args: [], context) =>
+        context.subscribedToUserDataLoader.loadMany(user.subscribedToUserIds),
+    },
+    userSubscribedTo: {
+      type: new GraphQLList(userType),
+      resolve: async (user: UserEntity, args: [], context) => context.userSubscribedToDataLoader.load(user.id),
     },
   }),
 })

--- a/src/routes/graphql/types/users.ts
+++ b/src/routes/graphql/types/users.ts
@@ -5,6 +5,8 @@ import {
   GraphQLList,
   GraphQLInputObjectType
 } from "graphql";
+import { UserEntity } from '../../../utils/DB/entities/DBUsers';
+import { profileType, postType, memberType } from "./";
 
 const userType = new GraphQLObjectType({
   name: "User",
@@ -14,6 +16,26 @@ const userType = new GraphQLObjectType({
     lastName: { type: new GraphQLNonNull(GraphQLString) },
     email: { type: new GraphQLNonNull(GraphQLString) },
     subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+    profile: {
+      type: profileType,
+      resolve: async (user: UserEntity, args: [], context) => context.profileDataLoader.load(user.id),
+    },
+    posts: {
+      type: postType,
+      resolve: async (user: UserEntity, args: [], context) => context.postDataLoader.load(user.id),
+    },
+    memberType: {
+      type: memberType,
+      resolve: async (user: UserEntity, args: [], context) => {
+        const profile = await context.profileDataLoader.load(user.id);
+
+        if (!profile) {
+          return
+        }
+
+        return context.memberTypeDataLoader.load(profile.memberTypeId);
+      },
+    },
   }),
 })
 

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -8,7 +8,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     MemberTypeEntity[]
-  > {});
+  > {
+    return this.db.memberTypes.findMany()
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +19,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const memberType = await this.db.memberTypes.findOne({
+        key: "id", equals: request.params.id
+      })
+
+      if (!memberType) {
+         throw this.httpErrors.notFound()
+      }
+
+      return memberType
+    }
   );
 
   fastify.patch(
@@ -28,7 +47,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      return await this.db.memberTypes.change(request.params.id, request.body)
+    }
   );
 };
 

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -32,7 +32,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       })
 
       if (!memberType) {
-         throw this.httpErrors.notFound()
+         return reply.notFound()
       }
 
       return memberType
@@ -47,7 +47,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {
+    async function (request, reply): Promise<MemberTypeEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams || !isValidBody) {
+        return reply.badRequest()
+      }
+
+      const memberType = await this.db.memberTypes.findOne({
+        key: "id", equals: request.params.id
+      })
+
+      if (!memberType) {
+        return reply.badRequest()
+      }
+
       return await this.db.memberTypes.change(request.params.id, request.body)
     }
   );

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -6,7 +6,9 @@ import type { PostEntity } from '../../utils/DB/entities/DBPosts';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {
+    return this.db.posts.findMany()
+  });
 
   fastify.get(
     '/:id',
@@ -15,7 +17,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const post = await this.db.posts.findOne({
+        key: "id", equals: request.params.id
+      })
+
+      if (!post) {
+        return reply.notFound()
+      }
+
+      return post
+    }
   );
 
   fastify.post(
@@ -25,7 +44,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createPostBodySchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      return await this.db.posts.create({
+        ...request.body
+      })
+    }
   );
 
   fastify.delete(
@@ -35,7 +58,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      return await this.db.posts.delete(request.params.id)
+    }
   );
 
   fastify.patch(
@@ -46,7 +71,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      return await this.db.posts.change(request.params.id, request.body)
+    }
   );
 };
 

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -58,7 +58,23 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {
+    async function (request, reply): Promise<PostEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const post =
+        await this.db.posts.findOne({
+          key: "id", equals: request.params.id
+        })
+
+      if (!post) {
+        return reply.badRequest()
+      }
+
       return await this.db.posts.delete(request.params.id)
     }
   );
@@ -71,7 +87,25 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {
+    async function (request, reply): Promise<PostEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidBody || !isValidParams) {
+        return reply.badRequest()
+      }
+
+      const post =
+        await this.db.posts.findOne({
+          key: "id", equals: request.params.id
+        })
+
+      if (!post) {
+        return reply.badRequest()
+      }
+
       return await this.db.posts.change(request.params.id, request.body)
     }
   );

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -8,7 +8,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     ProfileEntity[]
-  > {});
+  > {
+    return this.db.profiles.findMany()
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +19,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const profile = await this.db.profiles.findOne({
+        key: "id", equals: request.params.id
+      })
+
+      if (!profile) {
+        return reply.notFound()
+      }
+
+      return profile
+    }
   );
 
   fastify.post(
@@ -27,7 +46,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createProfileBodySchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity | void> {
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+
+      if (!isValidBody) {
+        return reply.badRequest()
+      }
+
+      return await this.db.profiles.create({
+        ...request.body
+      })
+    }
   );
 
   fastify.delete(
@@ -37,7 +67,25 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const profile =
+        await this.db.profiles.findOne({
+          key: "id", equals: request.params.id
+        })
+
+      if (!profile) {
+        return reply.notFound()
+      }
+
+      return await this.db.profiles.delete(request.params.id)
+    }
   );
 
   fastify.patch(
@@ -48,7 +96,27 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidBody || !isValidParams) {
+        return reply.badRequest()
+      }
+
+      const profile =
+        await this.db.profiles.findOne({
+          key: "id", equals: request.params.id
+        })
+
+      if (!profile) {
+        return reply.notFound()
+      }
+
+      return await this.db.profiles.change(request.params.id, request.body)
+    }
   );
 };
 

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -54,6 +54,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         return reply.badRequest()
       }
 
+      const profile = await this.db.profiles.findOne({
+        key: "userId", equals: request.body.userId
+      })
+
+      const memeberType = await this.db.memberTypes.findOne({
+        key: "id", equals: request.body.memberTypeId
+      })
+
+      if (profile || !memeberType) {
+        return reply.badRequest()
+      }
+
       return await this.db.profiles.create({
         ...request.body
       })
@@ -81,7 +93,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         })
 
       if (!profile) {
-        return reply.notFound()
+        return reply.badRequest()
       }
 
       return await this.db.profiles.delete(request.params.id)
@@ -112,7 +124,19 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         })
 
       if (!profile) {
-        return reply.notFound()
+        return reply.badRequest()
+      }
+
+      if (request.body.memberTypeId) {
+        const memberType =
+          await this.db.memberTypes.findOne({
+            key: "id",
+            equals: request.body.memberTypeId
+          })
+
+        if (!memberType) {
+          return reply.badRequest()
+        }
       }
 
       return await this.db.profiles.change(request.params.id, request.body)

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -10,7 +10,9 @@ import type { UserEntity } from '../../utils/DB/entities/DBUsers';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {
+    return await this.db.users.findMany()
+  });
 
   fastify.get(
     '/:id',
@@ -19,7 +21,25 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const result =
+        await this.db.users.findOne({
+          key: "id", equals: request.params.id
+        })
+
+      if (!result) {
+        return reply.notFound()
+      }
+
+      return result
+    }
   );
 
   fastify.post(
@@ -29,7 +49,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createUserBodySchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity | void> {
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+
+      if (!isValidBody) {
+        return reply.badRequest()
+      }
+
+      return await this.db.users.create({
+        ...request.body
+      })
+    }
   );
 
   fastify.delete(
@@ -39,7 +70,57 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidParams) {
+        return reply.badRequest()
+      }
+
+      const user =
+        await this.db.users.findOne({
+          key: "id", equals: request.params.id
+        })
+
+      if (!user) {
+        return reply.notFound()
+      }
+
+      const userProfile =
+        await this.db.profiles.findOne({ key: 'userId', equals: request.params.id })
+
+      if (userProfile) {
+        await this.db.profiles.delete(userProfile.id);
+      }
+
+      const userPosts =
+        await this.db.posts.findMany({ key: 'userId', equals: request.params.id })
+
+      await Promise.all(
+        userPosts?.map(async (post) => {
+          await this.db.posts.delete(post.id);
+        }),
+      )
+
+      const subscribedToUserArr =
+        await this.db.users.findMany({
+          key: 'subscribedToUserIds',
+          inArray: request.params.id
+        });
+
+      await Promise.all(
+        subscribedToUserArr.map(async (subscribedToUser) => {
+          const subscribedToUserIds =
+            subscribedToUser.subscribedToUserIds
+              .filter((userID) => userID !== request.params.id)
+
+          await this.db.users.change(subscribedToUser.id, { subscribedToUserIds });
+        }),
+      );
+
+      return await this.db.users.delete(request.params.id)
+    }
   );
 
   fastify.post(
@@ -50,7 +131,30 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity | void>{
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidBody || !isValidParams) {
+        return reply.badRequest()
+      }
+
+      const user = await this.db.users
+        .findOne({ key: "id", equals: request.params.id })
+
+      const subscribedToUser = await this.db.users
+        .findOne({ key: "id", equals: request.body.userId })
+
+      if (!user || !subscribedToUser) {
+        return reply.notFound()
+      }
+
+      user.subscribedToUserIds.push(request.body.userId)
+
+      return await this.db.users.change(request.params.id, user)
+    }
   );
 
   fastify.post(
@@ -61,7 +165,40 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidBody || !isValidParams) {
+        return reply.badRequest()
+      }
+
+      const user = await this.db.users
+        .findOne({ key: "id", equals: request.params.id })
+
+      const unSubscribedToUser = await this.db.users
+        .findOne({ key: "id", equals: request.body.userId })
+
+      if (!user || !unSubscribedToUser) {
+        return reply.notFound()
+      }
+
+      const isSubscribed =
+        user.subscribedToUserIds.some((userID) => userID === request.body.userId )
+
+      if (!isSubscribed) {
+        return reply.badRequest()
+      }
+
+      const subscribedToUserIds =
+        user.subscribedToUserIds.filter((userID) => userID !== request.body.userId)
+
+      user.subscribedToUserIds = [...subscribedToUserIds]
+
+      return await this.db.users.change(request.params.id, user)
+    }
   );
 
   fastify.patch(
@@ -72,7 +209,25 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity | void> {
+      const paramsValidationFunction = request.getValidationFunction('params')
+      const bodyValidationFunction = request.getValidationFunction('body')
+      const isValidBody = bodyValidationFunction(request.body)
+      const isValidParams = paramsValidationFunction(request.params)
+
+      if (!isValidBody || !isValidParams) {
+        return reply.badRequest()
+      }
+
+      const user = await this.db.users
+        .findOne({ key: "id", equals: request.params.id })
+
+      if (!user) {
+         return reply.notFound()
+      }
+
+      return await this.db.users.change(request.params.id, {...request.body})
+    }
   );
 };
 


### PR DESCRIPTION
[Graphql Basics](https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md)
Deadline - 31.01.2023

# **Basic Scope**
+72 Task 1: restful endpoints - Done
+72 Subtasks 2.1-2.7: get gql queries.
+54 Subtasks 2.8-2.11: create gql queries.
+54 Subtasks 2.12-2.17: update gql queries.
+88 Task 3: solve n+1 graphql problem.

SCORE: 340 / 360

# **How to test:**
**Subtasks 2.1-2.7: get gql queries.**

**2.1. Get users, profiles, posts, memberTypes - 4 operations in one query.**
QUERY:
```
{
    fetchUsers {
        id
        profile { id }
        posts { id }
        memberType { id }
    }
}
```

**2.2. Get user, profile, post, memberType by id - 4 operations in one query.**
QUERY:
```
query ($id: String!){
   fetchUser(id: $id) {
       id
       profile { id }
       posts { id }
       memberType { id }
   } 
}
```

VARIABLES:
```
{
  "id": "USER_UUID"    <---- PUT USER UUID HERE
}   
```

**2.3. Get users with their posts, profiles, memberTypes.**
QUERY:
```
{
    fetchUsers {
        id
        profile { id }
        posts { id }
        memberType { id }
    }
}
```

**2.4. Get user by id with his posts, profile, memberType.**
QUERY:
```
query ($id: String!){
   fetchUser(id: $id) {
       id
       profile { id }
       posts { id }
       memberType { id }
   } 
}
```

**2.5. Get users with their userSubscribedTo, profile.**
QUERY:
```
{
    fetchUsers {
        id
        profile { id }
        userSubscribedTo { id }
    }
}
```

**2.6. Get user by id with his subscribedToUser, posts.**
QUERY:
```
query ($id: String!){
    fetchUser(id: $id) {
        id
        posts { id }
        subscribedToUser { id }
    }
}
```

VARIABLES:
```
{
  "id": "USER_UUID",   <---- PUT USER UUID HERE
}
```

**2.7. Get users with their userSubscribedTo, subscribedToUser (additionally for each user in userSubscribedTo, subscribedToUser add their userSubscribedTo, subscribedToUser).**
QUERY:
```
{
    fetchUsers {
        id
        userSubscribedTo { id }
        subscribedToUser { id }
    }
}
```

```
{
    fetchUsers {
        id
        userSubscribedTo { 
            id
            subscribedToUser { id }
        }
        subscribedToUser { 
            id
            userSubscribedTo { id }
        }
    }
}
```

**Subtasks 2.8-2.11: create gql queries.**

**2.8. Create user.**
QUERY:
```
mutation ($user: CreateUserInput!){
    createUser(user: $user) {
       id
       firstName
       lastName
       email
   } 
}
```

VARIABLES:
```
{
   "user": {
     "firstName": "Luke",
     "lastName": "Skywalker",
     "email": "luke.skywalker@starwars.com"
   } 
}
```

**2.9. Create profile.**
QUERY:
```
mutation ($profile: CreateProfileInput!){
   createProfile(profile: $profile) {
       id
       avatar
       sex
       birthday
       country
       street
       city
       userId
       memberTypeId
   } 
}
```

VARIABLES:
```
{
  "profile": {
     "avatar": "avatar",
     "sex": "male",
     "birthday": "08.10.1900",
     "country": "usa",
     "street": "street",
     "city": "city",
     "userId": "USER_UUID",   <---- PUT USER UUID HERE
     "memberTypeId": ""
  }
}
```

**2.10. Create post.**
QUERY:
```
mutation ($post: CreatePostInput!){
   createPost(post: $post) {
       id
       userId
       title
       content
   } 
}
```

VARIABLES:
```
{
    "post": {
      "content": "test content",  
      "userId": "USER_UUID",   <---- PUT USER UUID HERE
      "title": "test title"
    }
}
```

**Subtasks 2.12-2.17: update gql queries.**

**2.12. Update user.**
QUERY:
```
mutation ($user: UpdateUserInput!){
   updateUser(user: $user) {
       id
       firstName
       lastName
       email
   } 
}
```

VARIABLES:
```
{
   "user": {
     "firstName": "Luke",
     "lastName": "Skywalker",
     "email": "luke.skywalker@starwars.com",
     "id": "USER_UUID"    <----PUT USER UUID HERE
   } 
}
```

**2.13. Update profile.**
QUERY:
```
mutation ($profile: UpdateProfileInput!){
   updateProfile(profile: $profile) {
       id
       city
   } 
}
```

VARIABLES:
```
{
  "profile": {
     "avatar": "updated avatar",
     "sex": "male",
     "birthday": "08.10.1900",
     "country": "usa",
     "street": "street",
     "city": "city",
     "id": "PROFILE_UUID",   <---- PUT PROFILE UUID HERE
     "memberTypeId": ""
  }
}
```

**2.14. Update post.**
QUERY:
```
mutation ($post: UpdatePostInput!){
   updatePost(post: $post) {
       id
       title
       content
   } 
}
```

VARIABLES:
```
{
    "post": {
       "content": "updated content",  
       "id": "POST_UUID",    <----PUT POST UUID HERE
       "title": "test title"
    }
}
```

**2.15. Update memberType.**
QUERY:
```
mutation ($memberType: UpdateMemberTypeInput!){
   updateMemberType(memberType: $memberType) {
       id
       discount
       monthPostsLimit
   } 
}
```

VARIABLES:
```
{
    "memberType": {
       "discount": "updated discount",  
       "id": "MEMBER_TYPE_UUID",    <----PUT MEMBER TYPE UUID HERE
       "monthPostsLimit": "1"
    }
}
```

**2.16. Subscribe to; unsubscribe from.**
QUERY:
```
mutation ($user: SubscribeToUserInput!){
   subscribeToUser(user: $user) {
       id
   } 
}
```

VARIABLES:
```
{
   "user": {
     "userId": "USER_UUID",    <---- PUT USER UUID HERE
     "subscribeToUserId": "USER_UUID"    <---- PUT USER UUID HERE
   } 
}
```
QUERY:
```
mutation ($user: UnsubscribeFromUserInput!){
   unsubscribeFromUser(user: $user) {
       id
   } 
}
```

VARIABLES:
```
{
   "user": {
     "userId": "USER_UUID",    <---- PUT USER UUID HERE
     "unsubscribeFromUserId": "USER_UUID"    <---- PUT USER UUID HERE
   } 
}
```

3. Solve n+1 graphql problem with [dataloader](https://www.npmjs.com/package/dataloader) package in all places where it should be used.
You can use only one "findMany" call per loader to consider this task completed.
It's ok to leave the use of the dataloader even if only one entity was requested. But additionally (no extra score) you can optimize the behavior for such cases => +1 db call is allowed per loader.
3.1. List where the dataloader was used with links to the lines of code (creation in gql context and call in resolver).

- creation in gql contex [here](https://github.com/Tonya-Mazakova/rsschool-nodejs-task-graphql/blob/feature/graphql/src/routes/graphql/index.ts)

- call in resolver - [user type](https://github.com/Tonya-Mazakova/rsschool-nodejs-task-graphql/blob/feature/graphql/src/routes/graphql/types/users.ts), [user resolver](https://github.com/Tonya-Mazakova/rsschool-nodejs-task-graphql/blob/feature/graphql/src/routes/graphql/resolvers/users.resolver.ts), [profile resolver](https://github.com/Tonya-Mazakova/rsschool-nodejs-task-graphql/blob/feature/graphql/src/routes/graphql/resolvers/profile.resolver.ts), [post resolver](https://github.com/Tonya-Mazakova/rsschool-nodejs-task-graphql/blob/feature/graphql/src/routes/graphql/resolvers/post.resolver.ts), [member type resolver](https://github.com/Tonya-Mazakova/rsschool-nodejs-task-graphql/blob/feature/graphql/src/routes/graphql/resolvers/memberType.resolver.ts)